### PR TITLE
Adding CWL and bedpe output format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,11 @@ RUN wget https://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.1/bowt
 
 # FusionInspector needs the TRINITY_HOME environment variable
 ENV TRINITY_HOME "/opt/trinityrnaseq-Trinity-v2.4.0/"
-ENV PATH "/opt/bowtie2-2.3.1:/opt/trinityrnaseq-Trinity-v2.4.0:/opt/FusionInspector-v1.0.1:$PATH"
+ENV PATH "/opt/bowtie2-2.3.1:/opt/trinityrnaseq-Trinity-v2.4.0:/opt/FusionInspector-v1.0.1:/opt:$PATH"
 
 # Add wrapper scripts
 COPY star_fusion_pipeline.py /opt/star_fusion_pipeline.py
+COPY convert_star_to_bedpe.py /opt/convert_star_to_bedpe.py
 COPY gene-list /home/gene-list
 COPY save-list /home/save-list
 COPY delete-list /home/delete-list

--- a/convert_star_to_bedpe.py
+++ b/convert_star_to_bedpe.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+# Copied from https://github.com/brianjohnhaas/Winterfell_SMC_RNA_DREAM2016/blob/master/STAR_Fusion/docker/convert_star_to_bedpe.py
+# KKD for Sage Bionetworks
+# June 13, 2016
+# Convert star-fusion output to BEDPE
+
+import sys
+
+with open(sys.argv[1], 'r') as starOutput:
+	for line in starOutput:
+		if not line.startswith('#'):
+			vals = line.strip().split()
+			valsL = vals[5].split(':')
+			valsR = vals[7].split(':')
+			chrL = valsL[0]
+			posL = valsL[1]
+			geneL = vals[4].split('^')[1]
+			strandL = valsL[2]
+			chrR = valsR[0]
+			posR = valsR[1]
+			geneR = vals[6].split('^')[1]
+			strandR = valsR[2]
+			bedpe = '\t'.join([chrL, str(int(posL)-1), posL, chrR, str(int(posR)-1), posR,'-'.join([geneL, geneR]), '0', strandL, strandR])
+			print bedpe

--- a/star_fusion_pipeline.py
+++ b/star_fusion_pipeline.py
@@ -8,7 +8,33 @@ import os
 import shutil
 import subprocess
 import sys
+import tarfile
 
+def untargz(input_targz_file, untar_to_dir):
+    """
+    This module accepts a tar.gz archive and untars it.
+    RETURN VALUE: path to the untar-ed directory/file
+    Copied from the ProTECT common library
+
+    NOTE: this module expects the multiple files to be in a directory before
+          being tar-ed.
+    """
+    print('Extracting STAR index.', file=sys.stderr)
+    assert tarfile.is_tarfile(input_targz_file), 'Not a tar file.'
+    tarball = tarfile.open(input_targz_file)
+    return_value = os.path.join(untar_to_dir, tarball.getmembers()[0].name)
+    tarball.extractall(path=untar_to_dir)
+    tarball.close()
+    return return_value
+
+def makeBedpe(infile, outfile):
+    """
+    Takes star-fusion-non-filtered.final or star-fusion-gene-list-filtered.final and creates bedpe format 
+    """
+    cmd = ['convert_star_to_bedpe.py', infile]
+    bedpe = subprocess.check_output(cmd)
+    with open(outfile, 'w') as o:
+        o.write(bedpe)
 
 def pipeline(args):
     """
@@ -45,6 +71,9 @@ def pipeline(args):
     results = os.path.abspath('%s/star-fusion-non-filtered.final' % args.output_dir)
     os.rename(output, results)
 
+    # Create bedpe format
+    makeBedpe(results, os.path.abspath('%s/star-fusion-non-filtered.final.bedpe' % args.output_dir))
+
     if args.skip_filter:
         print('Skipping filter.', file=sys.stderr)
 
@@ -76,6 +105,9 @@ def pipeline(args):
 
         # Update results file
         results = out_f.name
+
+        # Create bedpe format
+        makeBedpe(results, os.path.abspath('%s/star-fusion-gene-list-filtered.final.bedpe' % args.output_dir))
 
     if args.run_fusion_inspector:
         # Check input file for at least one fusion prediction
@@ -142,7 +174,7 @@ def main():
     parser.add_argument('--genome-lib-dir',
                         dest='genome_lib_dir',
                         required=True,
-                        help='Reference genome directory')
+                        help='Reference genome directory (can be tarfile)')
     parser.add_argument('--CPU',
                         default=str(multiprocessing.cpu_count()),
                         help='Number of jobs to run in parallel')
@@ -177,15 +209,22 @@ def main():
     args = parser.parse_args()
 
     # Check if output directory already exists. The final permissions are set
-    # to the permissions of the output directory.
+    # to the permissions of the output directory if run_as_root is not set.
     if not os.path.exists(args.output_dir):
-        raise ValueError('Stopping: output directory does not exist.')
+        if args.run_as_root:
+            os.mkdir(args.output_dir)
+        else:
+            raise ValueError('Stopping: output directory does not exist and run_as_root is not set.')
 
     # Check that output is not owned by root
     stat = os.stat(args.output_dir)
     # Note that the flag is root-ownership
     if not args.run_as_root and stat.st_uid == 0:
         raise ValueError('Stopping: output directory owned by root user.')
+
+    # Untar the genome directory if necessary
+    if os.path.isfile(args.genome_lib_dir):
+        args.genome_lib_dir = untargz(args.genome_lib_dir, '/tmp')
 
     # This is based on the Toil RNA-seq pipeline:
     # https://github.com/BD2KGenomics/toil-rnaseq/blob/master/docker/wrapper.py#L51

--- a/starfusion.cwl
+++ b/starfusion.cwl
@@ -1,0 +1,86 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+label: "STAR-fusion workflow by Jacob Pfeil; CWL by Jeltje van Baren"
+cwlVersion: v1.0
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: "ucsctreehouse/fusion:0.1.0"
+
+baseCommand: []
+
+inputs:
+
+  fastq1:
+    type: File
+    inputBinding:
+      prefix: --left-fq
+
+  fastq2:
+    type: File
+    inputBinding:
+      prefix: --right-fq
+
+  outputdir:
+    type: string
+    default: starfusion_out 
+    inputBinding:
+      prefix: --output-dir
+
+  index:
+    type: File
+    inputBinding:
+      prefix: --genome-lib-dir
+
+  cpu:
+    type: int
+    default: 8
+    inputBinding:
+      prefix: --CPU
+
+  genelist:
+    type: File?
+    inputBinding:
+      prefix: --genelist
+
+  skip_filter:
+    type: boolean
+    default: False
+    inputBinding:
+      prefix: --skip-filter
+
+  inspect:
+    type: boolean
+    default: False
+    inputBinding:
+      prefix: --run-fusion-inspector
+
+  save_intermediates:
+    type: boolean
+    default: False
+    inputBinding:
+      prefix: --save-intermediates
+
+  root-ownership:
+    type: boolean
+    default: False
+    inputBinding:
+      prefix: --root-ownership
+
+  test:
+    type: boolean
+    default: False
+    inputBinding:
+      prefix: --test
+
+outputs:
+
+  output:
+    type: Directory
+    outputBinding:
+       glob: $(inputs.outputdir)
+
+
+
+


### PR DESCRIPTION
Three changes:

1. Adding bedpe converter that creates `star-fusion-gene-list-filtered.final.bedpe` and `star-fusion-non-filtered.final.bedpe`. I have not added these files to the `save-list` because that list doesn't get used in the code.
2. Adding option to input a tar.gz `genome-lib-dir`. The program now checks the input to see if untarring is needed, then does so if necessary. This is needed for using CWL on Dockstore.
3. Adding CWL file that runs ucsctreehouse/fusion:0.1.0. To make this work properly, the docker image should be recreated after this PR has been merged.

One minor change:
If the progam is run with `--root-ownership`, it will create the output directory if it doesn't exist. This facilitates running batches using Dockstore.